### PR TITLE
fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,31 +111,46 @@ Available targets:
   lint                                Lint terraform code
 
 ```
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| aws | ~> 2.0 |
+| local | ~> 1.2 |
+| null | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.0 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| acl | Canned ACL to apply to the S3 bucket | string | `log-delivery-write` | no |
-| attributes | Additional attributes (e.g. `logs`) | list(string) | `<list>` | no |
-| delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
-| enabled | Set to `false` to prevent the module from creating any resources | bool | `true` | no |
-| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | string | `` | no |
-| force_destroy | A boolean that indicates the bucket can be destroyed even if it contains objects. These objects are not recoverable | bool | `false` | no |
-| lifecycle_prefix | Prefix filter. Used to manage object lifecycle events | string | `` | no |
-| name | Name  (e.g. `app` or `cluster`) | string | - | yes |
-| namespace | Namespace (e.g. `cp` or `cloudposse`) | string | `` | no |
-| region | AWS Region for S3 bucket | string | - | yes |
-| stage | Stage (e.g. `prod`, `dev`, `staging`) | string | `` | no |
-| tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map(string) | `<map>` | no |
+|------|-------------|------|---------|:--------:|
+| acl | Canned ACL to apply to the S3 bucket | `string` | `"log-delivery-write"` | no |
+| attributes | Additional attributes (e.g. `logs`) | `list(string)` | `[]` | no |
+| delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
+| enabled | Set to `false` to prevent the module from creating any resources | `bool` | `true` | no |
+| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
+| force\_destroy | A boolean that indicates the bucket can be destroyed even if it contains objects. These objects are not recoverable | `bool` | `false` | no |
+| lifecycle\_prefix | Prefix filter. Used to manage object lifecycle events | `string` | `""` | no |
+| name | Name  (e.g. `app` or `cluster`) | `string` | n/a | yes |
+| namespace | Namespace (e.g. `cp` or `cloudposse`) | `string` | `""` | no |
+| region | AWS Region for S3 bucket | `string` | n/a | yes |
+| stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
+| tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| bucket_arn | S3 bucket ARN |
-| bucket_domain_name | S3 bucket domain name |
-| bucket_id | S3 bucket ID |
-| bucket_prefix | S3 bucket prefix |
+| bucket\_arn | S3 bucket ARN |
+| bucket\_domain\_name | S3 bucket domain name |
+| bucket\_id | S3 bucket ID |
+| bucket\_prefix | S3 bucket prefix |
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,26 +1,41 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| aws | ~> 2.0 |
+| local | ~> 1.2 |
+| null | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.0 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| acl | Canned ACL to apply to the S3 bucket | string | `log-delivery-write` | no |
-| attributes | Additional attributes (e.g. `logs`) | list(string) | `<list>` | no |
-| delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
-| enabled | Set to `false` to prevent the module from creating any resources | bool | `true` | no |
-| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | string | `` | no |
-| force_destroy | A boolean that indicates the bucket can be destroyed even if it contains objects. These objects are not recoverable | bool | `false` | no |
-| lifecycle_prefix | Prefix filter. Used to manage object lifecycle events | string | `` | no |
-| name | Name  (e.g. `app` or `cluster`) | string | - | yes |
-| namespace | Namespace (e.g. `cp` or `cloudposse`) | string | `` | no |
-| region | AWS Region for S3 bucket | string | - | yes |
-| stage | Stage (e.g. `prod`, `dev`, `staging`) | string | `` | no |
-| tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map(string) | `<map>` | no |
+|------|-------------|------|---------|:--------:|
+| acl | Canned ACL to apply to the S3 bucket | `string` | `"log-delivery-write"` | no |
+| attributes | Additional attributes (e.g. `logs`) | `list(string)` | `[]` | no |
+| delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
+| enabled | Set to `false` to prevent the module from creating any resources | `bool` | `true` | no |
+| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
+| force\_destroy | A boolean that indicates the bucket can be destroyed even if it contains objects. These objects are not recoverable | `bool` | `false` | no |
+| lifecycle\_prefix | Prefix filter. Used to manage object lifecycle events | `string` | `""` | no |
+| name | Name  (e.g. `app` or `cluster`) | `string` | n/a | yes |
+| namespace | Namespace (e.g. `cp` or `cloudposse`) | `string` | `""` | no |
+| region | AWS Region for S3 bucket | `string` | n/a | yes |
+| stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
+| tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| bucket_arn | S3 bucket ARN |
-| bucket_domain_name | S3 bucket domain name |
-| bucket_id | S3 bucket ID |
-| bucket_prefix | S3 bucket prefix |
+| bucket\_arn | S3 bucket ARN |
+| bucket\_domain\_name | S3 bucket domain name |
+| bucket\_id | S3 bucket ID |
+| bucket\_prefix | S3 bucket prefix |
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -1,4 +1,4 @@
-region = "us-west-1"
+region = "us-east-2"
 
 namespace = "eg"
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -11,5 +11,6 @@ module "lb_s3_bucket" {
   stage         = var.stage
   name          = var.name
   acl           = var.acl
+  attributes    = var.attributes
   force_destroy = var.force_destroy
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -18,6 +18,11 @@ variable "name" {
   description = "Name  (e.g. `app` or `cluster`)"
 }
 
+variable "attributes" {
+  default = []
+  type    = list(string)
+}
+
 variable "acl" {
   type        = string
   description = "Canned ACL to apply to the S3 bucket"

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -1,22 +1,31 @@
 package test
 
 import (
-	"testing"
-
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
 )
 
 // Test the Terraform module in examples/complete using Terratest.
 func TestExamplesComplete(t *testing.T) {
 	t.Parallel()
 
+	rand.Seed(time.Now().UnixNano())
+
+	attributes := []string{strconv.Itoa(rand.Intn(100000))}
+
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located
 		TerraformDir: "../../examples/complete",
 		Upgrade:      true,
 		// Variables to pass to our Terraform code using -var-file options
-		VarFiles: []string{"fixtures.us-west-1.tfvars"},
+		VarFiles: []string{"fixtures.us-east-2.tfvars"},
+		Vars: map[string]interface{}{
+			"attributes": attributes,
+		},
 	}
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created
@@ -28,7 +37,7 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	s3BucketId := terraform.Output(t, terraformOptions, "bucket_id")
 
-	expectedS3BucketId := "eg-test-lb-s3-test"
+	expectedS3BucketId := "eg-test-lb-s3-test-" + attributes[0]
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, expectedS3BucketId, s3BucketId)
 }


### PR DESCRIPTION
## what
* Move tests to `us-east-2`
* Generate random attribute to ensure unique buckets that don't conflict with other tests

## why
* All cloud posse tests run in `us-east-2` so we can simplify cleanup
* Tests frequently orphan resources like buckets. Generating bucket names randomly helps ensure uniqueness