### PR TITLE
Bump terraform-aws-s3-log-storage to 0.13.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "default" {
 }
 
 module "s3_bucket" {
-  source                             = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.11.0"
+  source                             = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.13.0"
   enabled                            = var.enabled
   namespace                          = var.namespace
   stage                              = var.stage


### PR DESCRIPTION
## what
* uses https://github.com/cloudposse/terraform-aws-s3-log-storage/releases/tag/0.13.0

## why
* true TF 0.13.0 support

## references
* should be included with https://github.com/cloudposse/terraform-aws-lb-s3-bucket/pull/17