### PR TITLE
update aws providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,13 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.34, < 4.0 |
 | local | ~> 1.2 |
 | null | ~> 2.0 |
 
@@ -106,7 +107,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.34, < 4.0 |
 
 ## Inputs
 
@@ -127,7 +128,6 @@ Available targets:
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | `string` | `""` | no |
 | noncurrent\_version\_expiration\_days | Specifies when noncurrent s3 log versions expire | `number` | `90` | no |
 | noncurrent\_version\_transition\_days | Specifies when noncurrent s3 log versions transition | `number` | `30` | no |
-| region | AWS Region for S3 bucket | `string` | n/a | yes |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
 | standard\_transition\_days | Number of days to persist logs in standard storage tier before moving to the infrequent access tier | `number` | `30` | no |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | `map(string)` | `{}` | no |
@@ -141,6 +141,7 @@ Available targets:
 | bucket\_id | S3 bucket ID |
 | bucket\_prefix | S3 bucket prefix |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,9 +1,10 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.34, < 4.0 |
 | local | ~> 1.2 |
 | null | ~> 2.0 |
 
@@ -11,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.34, < 4.0 |
 
 ## Inputs
 
@@ -32,7 +33,6 @@
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | `string` | `""` | no |
 | noncurrent\_version\_expiration\_days | Specifies when noncurrent s3 log versions expire | `number` | `90` | no |
 | noncurrent\_version\_transition\_days | Specifies when noncurrent s3 log versions transition | `number` | `30` | no |
-| region | AWS Region for S3 bucket | `string` | n/a | yes |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
 | standard\_transition\_days | Number of days to persist logs in standard storage tier before moving to the infrequent access tier | `number` | `30` | no |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | `map(string)` | `{}` | no |
@@ -46,3 +46,4 @@
 | bucket\_id | S3 bucket ID |
 | bucket\_prefix | S3 bucket prefix |
 
+<!-- markdownlint-restore -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -6,7 +6,6 @@ module "lb_s3_bucket" {
   source = "../../"
 
   enabled       = true
-  region        = var.region
   namespace     = var.namespace
   stage         = var.stage
   name          = var.name

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "default" {
 }
 
 module "s3_bucket" {
-  source                             = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.13.1"
+  source                             = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.13.2"
   enabled                            = var.enabled
   namespace                          = var.namespace
   stage                              = var.stage

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,6 @@ module "s3_bucket" {
   stage                              = var.stage
   environment                        = var.environment
   name                               = var.name
-  region                             = var.region
   acl                                = var.acl
   policy                             = join("", data.aws_iam_policy_document.default.*.json)
   force_destroy                      = var.force_destroy

--- a/variables.tf
+++ b/variables.tf
@@ -51,11 +51,6 @@ variable "acl" {
   default     = "log-delivery-write"
 }
 
-variable "region" {
-  type        = string
-  description = "AWS Region for S3 bucket"
-}
-
 variable "force_destroy" {
   type        = bool
   description = "A boolean that indicates the bucket can be destroyed even if it contains objects. These objects are not recoverable"

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
-    aws   = ">= 2.0, < 4.0"
-    local = "~> 1.2"
-    null  = "~> 2.0"
+    aws   = ">= 2.0"
+    local = ">= 1.2"
+    null  = ">= 2.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws   = ">= 2.34, < 4.0"
+    aws   = ">= 2.0, < 4.0"
     local = "~> 1.2"
     null  = "~> 2.0"
   }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws   = "~> 2.0"
+    aws   = ">= 2.34, < 4.0"
     local = "~> 1.2"
     null  = "~> 2.0"
   }


### PR DESCRIPTION
## what
* support aws 3.x provider
* DEPENDENCY: https://github.com/cloudposse/terraform-aws-s3-log-storage/pull/38

## why
* enable using with other modules requiring aws 3.x provider

## references
* requires 3.x: https://github.com/cloudposse/terraform-aws-ecr/blob/master/main.tf#L30