### PR TITLE
Updated module terraform-aws-s3-log-storage tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,20 +93,21 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
-| local | ~> 1.2 |
-| null | ~> 2.0 |
+| terraform | >= 0.12.0 |
+| aws | >= 2.0 |
+| local | >= 1.2 |
+| null | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -141,6 +142,7 @@ Available targets:
 | bucket\_id | S3 bucket ID |
 | bucket\_prefix | S3 bucket prefix |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ Available targets:
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | `string` | `""` | no |
 | noncurrent\_version\_expiration\_days | Specifies when noncurrent s3 log versions expire | `number` | `90` | no |
 | noncurrent\_version\_transition\_days | Specifies when noncurrent s3 log versions transition | `number` | `30` | no |
-| region | AWS Region for S3 bucket | `string` | n/a | yes |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
 | standard\_transition\_days | Number of days to persist logs in standard storage tier before moving to the infrequent access tier | `number` | `30` | no |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ module "s3_bucket" {
   namespace = "eg"
   stage     = "test"
   name      = "cluster"
-  region    = "us-east-1"
 }
 ```
 

--- a/README.yaml
+++ b/README.yaml
@@ -22,7 +22,6 @@ usage: |-
     namespace = "eg"
     stage     = "test"
     name      = "cluster"
-    region    = "us-east-1"
   }
   ```
 include:

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,17 +1,18 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
-| local | ~> 1.2 |
-| null | ~> 2.0 |
+| terraform | >= 0.12.0 |
+| aws | >= 2.0 |
+| local | >= 1.2 |
+| null | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -46,3 +47,4 @@
 | bucket\_id | S3 bucket ID |
 | bucket\_prefix | S3 bucket prefix |
 
+<!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -33,7 +33,6 @@
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | `string` | `""` | no |
 | noncurrent\_version\_expiration\_days | Specifies when noncurrent s3 log versions expire | `number` | `90` | no |
 | noncurrent\_version\_transition\_days | Specifies when noncurrent s3 log versions transition | `number` | `30` | no |
-| region | AWS Region for S3 bucket | `string` | n/a | yes |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
 | standard\_transition\_days | Number of days to persist logs in standard storage tier before moving to the infrequent access tier | `number` | `30` | no |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | `map(string)` | `{}` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -6,7 +6,6 @@ module "lb_s3_bucket" {
   source = "../../"
 
   enabled       = true
-  region        = var.region
   namespace     = var.namespace
   stage         = var.stage
   name          = var.name

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,8 +1,3 @@
-variable "region" {
-  type        = string
-  description = "AWS Region for S3 bucket"
-}
-
 variable "namespace" {
   type        = string
   description = "Namespace (e.g. `eg` or `cp`)"

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "default" {
 }
 
 module "s3_bucket" {
-  source                             = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.13.1"
+  source                             = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.14.0"
   enabled                            = var.enabled
   namespace                          = var.namespace
   stage                              = var.stage

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,6 @@ module "s3_bucket" {
   stage                              = var.stage
   environment                        = var.environment
   name                               = var.name
-  region                             = var.region
   acl                                = var.acl
   policy                             = join("", data.aws_iam_policy_document.default.*.json)
   force_destroy                      = var.force_destroy

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "default" {
 }
 
 module "s3_bucket" {
-  source                             = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.14.0"
+  source                             = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.15.0"
   enabled                            = var.enabled
   namespace                          = var.namespace
   stage                              = var.stage

--- a/variables.tf
+++ b/variables.tf
@@ -51,11 +51,6 @@ variable "acl" {
   default     = "log-delivery-write"
 }
 
-variable "region" {
-  type        = string
-  description = "AWS Region for S3 bucket"
-}
-
 variable "force_destroy" {
   type        = bool
   description = "A boolean that indicates the bucket can be destroyed even if it contains objects. These objects are not recoverable"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
     aws   = ">= 2.0"

--- a/versions.tf
+++ b/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws   = "~> 2.0"
-    local = "~> 1.2"
-    null  = "~> 2.0"
+    aws   = ">= 2.0"
+    local = ">= 1.2"
+    null  = ">= 2.0"
   }
 }


### PR DESCRIPTION
Updated module terraform-aws-s3-log-storage tag to 0.14.0. The tag 0.13.1 causes error with Terraform 0.13:

```
Error: Failed to query available provider packages
Could not retrieve the list of available versions for provider hashicorp/aws:
no available releases match the given constraints >= 3.0.*, >= 2.0.*, >=
2.0.*, >= 2.0.*, >= 2.0.*, >= 2.0.*, < 4.0.*, ~> 2.0, ~> 2.0, ~> 2.0, ~> 2.0,
~> 2.0, ~> 2.0, >= 2.0.*, < 4.0.*, >= 3.0.*, >= 2.0.*, >= 2.0.*, >= 2.0.*
```

## what
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.

## why
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`

