### PR TITLE
aws-alb module terraform 0.14.0 support

### DIFF
--- a/context.tf
+++ b/context.tf
@@ -19,7 +19,8 @@
 #
 
 module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+  source  = "cloudposse/label/null"
+  version = "0.22.1"
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,8 @@ data "aws_iam_policy_document" "default" {
 }
 
 module "s3_bucket" {
-  source                             = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.14.0"
+  source                             = "cloudposse/s3-log-storage/aws"
+  version                            = "0.15.1"
   context                            = module.this.context
   acl                                = var.acl
   policy                             = join("", data.aws_iam_policy_document.default.*.json)


### PR DESCRIPTION
## what

* Bump the `null-label` module, in context.tf, `from 0.19.2 to 0.22.1`
* Bump the `s3-log-storage` module, in main.tf, `from 0.14.0 to 0.15.1`

## why

* The latest version of the [aws-alb](https://github.com/cloudposse/terraform-aws-alb) module does not work with Terraform 0.14.x because it calls this very module which
  * Uses the `null-label` module `version 0.19.2` which [does not support Terraform 0.14.x](https://github.com/cloudposse/terraform-null-label/blob/0.19.2/versions.tf)
  * Uses the `s3-log-storage` module `version 0.14.0` which [uses the 0.19.2 version of the null-label module](https://github.com/cloudposse/terraform-aws-s3-log-storage/blob/0.14.0/context.tf#L22) in its `context.tf` file. The `version 0.15.1` [uses a compatible null-label version](https://github.com/cloudposse/terraform-aws-s3-log-storage/blob/0.15.1/context.tf#L23-L24).

## comments

* Using the `aws-alb` module version `0.26.0` in my tests
* I chose to bump the `s3-log-storage` module to `0.15.1` because I didn't have time to review all the changes up to the latest version. I might have some free time to do in the next week if needs be
* I tested this by forking this repo, applying the changes listed in this PR. I then forked the aws-alb repo and updated the [access_log module source](https://github.com/cloudposse/terraform-aws-alb/blob/master/main.tf#L42-L43) to point on my branch.

