### PR TITLE
feature:Add bucket_name variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+locals {
+  bucket_name = var.bucket_name != null && var.bucket_name != "" ? var.bucket_name : module.this.id
+}
+
 data "aws_elb_service_account" "default" {
   count = module.this.enabled ? 1 : 0
 }
@@ -58,6 +62,7 @@ module "s3_bucket" {
   source                             = "cloudposse/s3-log-storage/aws"
   version                            = "0.24.0"
   context                            = module.this.context
+  bucket                             = local.bucket_name
   acl                                = var.acl
   policy                             = join("", data.aws_iam_policy_document.default.*.json)
   force_destroy                      = var.force_destroy

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "acl" {
   default     = "log-delivery-write"
 }
 
+variable "bucket_name" {
+  type        = string
+  default     = null
+  description = "Bucket name. If provided, the bucket will be created with this name instead of generating the name from the context"
+}
+
 variable "force_destroy" {
   type        = bool
   description = "A boolean that indicates the bucket can be destroyed even if it contains objects. These objects are not recoverable"


### PR DESCRIPTION
## what
* Allow the exact bucket name to be specified, overriding the context.id generated name


## why
* Allows bucket name to follow different naming convention when required

## references
* closes #41

