### PR TITLE
Add support for other AWS partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Available targets:
 |------|------|
 | [aws_elb_service_account.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) | data source |
 | [aws_iam_policy_document.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -27,6 +27,7 @@
 |------|------|
 | [aws_elb_service_account.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) | data source |
 | [aws_iam_policy_document.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "default" {
       "s3:PutObject"
     ]
     resources = [
-      "arn:aws:s3:::${module.this.id}/*",
+      "arn:${data.aws_partition.current.partition}:s3:::${module.this.id}/*",
     ]
   }
   statement {
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "default" {
       "s3:PutObject"
     ]
     resources = [
-      "arn:aws:s3:::${module.this.id}/*",
+      "arn:${data.aws_partition.current.partition}:s3:::${module.this.id}/*",
     ]
     condition {
       test     = "StringEquals"
@@ -49,10 +49,12 @@ data "aws_iam_policy_document" "default" {
       "s3:GetBucketAcl"
     ]
     resources = [
-      "arn:aws:s3:::${module.this.id}",
+      "arn:${data.aws_partition.current.partition}:s3:::${module.this.id}",
     ]
   }
 }
+
+data "aws_partition" "current" {}
 
 module "s3_bucket" {
   source                             = "cloudposse/s3-log-storage/aws"


### PR DESCRIPTION
## what
* Add support for other AWS partitions (China, GovCloud)

## why
* AWS China and AWS GovCloud exist
* `arn:aws:` should never be hardcoded because of this

