### PR TITLE
Fix bucket name in policy statements, fixing #81

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Available targets:
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_bucket_name"></a> [bucket\_name](#module\_bucket\_name) | cloudposse/label/null | 0.25.0 |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | cloudposse/s3-log-storage/aws | 1.4.2 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -16,6 +16,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_bucket_name"></a> [bucket\_name](#module\_bucket\_name) | cloudposse/label/null | 0.25.0 |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | cloudposse/s3-log-storage/aws | 1.4.2 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 

--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "default" {
       "s3:PutObject"
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:s3:::${var.bucket_name}/*",
+      "arn:${data.aws_partition.current.partition}:s3:::${local.bucket_name}/*",
     ]
     condition {
       test     = "StringEquals"

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "default" {
       "s3:PutObject"
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:s3:::${var.bucket_name}/*",
+      "arn:${data.aws_partition.current.partition}:s3:::${local.bucket_name}/*",
     ]
   }
 

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,7 @@ data "aws_iam_policy_document" "default" {
       "s3:GetBucketAcl"
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:s3:::${var.bucket_name}",
+      "arn:${data.aws_partition.current.partition}:s3:::${local.bucket_name}",
     ]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,20 @@
+locals {
+  enabled = module.this.enabled
+  # We do not use coalesce() here because it is OK if local.bucket_name is empty.
+  bucket_name = var.bucket_name == null || var.bucket_name == "" ? module.bucket_name.id : var.bucket_name
+}
+
+module "bucket_name" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  enabled = local.enabled && try(length(var.bucket_name) == 0, false)
+
+  id_length_limit = 63 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+
+  context = module.this.context
+}
+
 data "aws_elb_service_account" "default" {
   count = module.this.enabled ? 1 : 0
 }

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "default" {
       "s3:PutObject"
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:s3:::${module.this.id}/*",
+      "arn:${data.aws_partition.current.partition}:s3:::${var.bucket_name}/*",
     ]
   }
 
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "default" {
       "s3:PutObject"
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:s3:::${module.this.id}/*",
+      "arn:${data.aws_partition.current.partition}:s3:::${var.bucket_name}/*",
     ]
     condition {
       test     = "StringEquals"
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "default" {
       "s3:GetBucketAcl"
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:s3:::${module.this.id}",
+      "arn:${data.aws_partition.current.partition}:s3:::${var.bucket_name}",
     ]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ module "bucket_name" {
   source  = "cloudposse/label/null"
   version = "0.25.0"
 
-  enabled = local.enabled && try(length(var.bucket_name) == 0, false)
+  enabled = local.enabled && try(length(var.bucket_name) == 0, true)
 
   id_length_limit = 63 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
-  enabled = module.this.enabled
+  enabled              = module.this.enabled
   generate_bucket_name = module.this.enabled && try(length(var.bucket_name) == 0, true) # Use `try` to handle `null` value
-  bucket_name = local.generate_bucket_name ? module.bucket_name.id : var.bucket_name
+  bucket_name          = local.generate_bucket_name ? module.bucket_name.id : var.bucket_name
 }
 
 module "bucket_name" {

--- a/main.tf
+++ b/main.tf
@@ -1,14 +1,14 @@
 locals {
   enabled = module.this.enabled
-  # We do not use coalesce() here because it is OK if local.bucket_name is empty.
-  bucket_name = var.bucket_name == null || var.bucket_name == "" ? module.bucket_name.id : var.bucket_name
+  generate_bucket_name = module.this.enabled && try(length(var.bucket_name) == 0, true) # Use `try` to handle `null` value
+  bucket_name = local.generate_bucket_name ? module.bucket_name.id : var.bucket_name
 }
 
 module "bucket_name" {
   source  = "cloudposse/label/null"
   version = "0.25.0"
 
-  enabled = local.enabled && try(length(var.bucket_name) == 0, true)
+  enabled = local.generate_bucket_name
 
   id_length_limit = 63 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   enabled              = module.this.enabled
-  generate_bucket_name = module.this.enabled && try(length(var.bucket_name) == 0, true) # Use `try` to handle `null` value
+  generate_bucket_name = local.enabled && try(length(var.bucket_name) == 0, true) # Use `try` to handle `null` value
   bucket_name          = local.generate_bucket_name ? module.bucket_name.id : var.bucket_name
 }
 


### PR DESCRIPTION
## what

- Limit generated S3 bucket name to 63 characters

## why

- AWS imposed limit, derived from DNS limits, allowing S3 buckets to be accessed by name via DNS

## references

- closes #81 
- Copy [bucket_name logic](https://github.com/cloudposse/terraform-aws-s3-log-storage/blob/main/main.tf#L1-L15) from dependent module

